### PR TITLE
fix: add placeholder field to empty struct generation for Solidity 0.…

### DIFF
--- a/generator/message_generator.go
+++ b/generator/message_generator.go
@@ -464,6 +464,9 @@ func (g *Generator) generateMessageStruct(descriptor *descriptorpb.DescriptorPro
 				b.P(fmt.Sprintf("%s%s %s;", fieldType, arrayStr, fieldName))
 			}
 		}
+	} else {
+		// Add placeholder field for empty struct (Solidity 0.8.19+ requirement)
+		b.P("bool _placeholder; // Placeholder field to avoid empty struct compilation error")
 	}
 
 	b.Unindent()


### PR DESCRIPTION
…8.19+ compatibility

- Add else clause to generateMessageStruct to handle empty messages
- Adds 'bool _placeholder;' field to prevent empty struct compilation errors
- Fixes issue where protoc-gen-sol only handled google.protobuf.Empty but not custom empty messages
- Resolves Solidity 0.8.19+ requirement that structs cannot be empty

Resolves empty struct compilation errors for messages like GetAgentCardRequest in A2A protocol.